### PR TITLE
TRT-01178

### DIFF
--- a/app/js/controllers/GC/recipientsCtrl.js
+++ b/app/js/controllers/GC/recipientsCtrl.js
@@ -53,6 +53,10 @@ four51.app.controller('RecipientsCtrl', ['$routeParams', '$sce', '$scope', '$451
         $scope.countries = Resources.countries;
         $scope.states = Resources.states;
 
+        $scope.country = function(item) {
+            return $scope.tempRecipient.Address != null ? $scope.tempRecipient.Address.Country == item.country : false;
+        };
+
         $scope.searchCriterion = {};
         $scope.employees = [];
         $scope.searchError = "";


### PR DESCRIPTION
This is a fix for the Canadian Providences not showing in the state drop-down when Canada is selected as the country on the Recipient creation screen.